### PR TITLE
Fix README rendering on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ ohproj-download
       --help                   Show this message and exit.
 
 ohproj-download-metadata
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
@@ -100,7 +100,7 @@ ohproj-download-metadata
       --help                Show this message and exit.
 
 ohproj-upload-metadata
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 


### PR DESCRIPTION
[docutils' reStructuredText specification][1] requires the underline beneath a section header to be at least as long as the section name.  This was not the case for the underlines beneath "ohproj-download-metadata" and "ohproj-upload-metadata" in `README.rst`, and so as a result [the project's README is not being rendered properly on PyPI][2].  This pull request fixes the README's markup.

For future reference, the markup in a project's README can be validated before publishing by installing [`readme_renderer`][3] and running `python setup.py check -r -s`.

[1]: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections
[2]: https://pypi.python.org/pypi/open-humans-api/0.1.2.3
[3]: https://pypi.python.org/pypi/readme_renderer
