### PR TITLE
Add VCR, test token exchange

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ python:
     - "3.6"
 
 install:
-  - pip install -e.
-  - pip install coverage
-  - pip install pytest-cov
+  - pip install -e .
+  - pip install -r dev-requirements.txt
 before_script:
   - mkdir bin
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > bin/cc-test-reporter

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
+vcrpy
 flake8

--- a/ohapi/api.py
+++ b/ohapi/api.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import json
 import logging
 import os
@@ -28,12 +29,12 @@ def oauth2_auth_url(redirect_uri=None, client_id=None, base_url=OH_BASE_URL):
             raise SettingsError(
                 "Client ID not provided! Provide client_id as a parameter, "
                 "or set OHAPI_CLIENT_ID in your environment.")
-    params = {
-        'client_id': client_id,
-        'response_type': 'code'
-    }
+    params = OrderedDict([
+        ('client_id', client_id),
+        ('response_type', 'code'),
+    ])
     if redirect_uri:
-        params.update({'redirect_uri': redirect_uri})
+        params['redirect_uri'] = redirect_uri
 
     auth_url = urlparse.urljoin(
         base_url, '/direct-sharing/projects/oauth2/authorize/?{}'.format(
@@ -192,4 +193,4 @@ def message(subject, message, access_token, all_members=False, project_member_id
         requests.post(url, data={'all_members': all_members,
                      'project_member_ids': project_member_ids,
                      'subject': subject,
-                     'message': message}) 
+                     'message': message})

--- a/ohapi/api.py
+++ b/ohapi/api.py
@@ -60,9 +60,9 @@ def oauth2_token_exchange(client_id, client_secret, redirect_uri,
             'grant_type': 'refresh_token',
             'refresh_token': refresh_token,
         }
+    token_url = urlparse.urljoin(base_url, '/oauth2/token/')
     req = requests.post(
-        '{}/oauth2/token/'.format(base_url),
-        data=data,
+        token_url, data=data,
         auth=requests.auth.HTTPBasicAuth(client_id, client_secret))
     data = req.json()
     return data

--- a/ohapi/api.py
+++ b/ohapi/api.py
@@ -175,22 +175,24 @@ def delete_files(*args, **kwargs):
     return delete_file(*args, **kwargs)
 
 
-def message(subject, message, access_token, all_members=False, project_member_ids=None, base_url=OH_BASE_URL):
+def message(subject, message, access_token, all_members=False,
+            project_member_ids=None, base_url=OH_BASE_URL):
     """
     send messages.
     """
     url = urlparse.urljoin(
         base_url, '/api/direct-sharing/project/message/?{}'.format(
-        urlparse.urlencode({'access_token': access_token})))
+            urlparse.urlencode({'access_token': access_token})))
     if not(all_members) and not(project_member_ids):
-        requests.post(url,data={'subject': subject,
-                                'message': message})
+        requests.post(url, data={'subject': subject,
+                                 'message': message})
     elif all_members and project_member_ids:
         raise ValueError(
             "One (and only one) of the following must be specified: "
             "project_members_id or all_members is set to True.")
     else:
-        requests.post(url, data={'all_members': all_members,
-                     'project_member_ids': project_member_ids,
-                     'subject': subject,
-                     'message': message})
+        requests.post(url, data={
+            'all_members': all_members,
+            'project_member_ids': project_member_ids,
+            'subject': subject,
+            'message': message})

--- a/ohapi/cassettes/__init__.py
+++ b/ohapi/cassettes/__init__.py
@@ -1,0 +1,33 @@
+"""
+VCR records of Open Humans API calls.
+
+Example usage:
+
+>>> from ohapi.cassettes import get_vcr
+>>> from ohapi.api import oauth2_token_exchange
+>>> with ohapi_vcr.use_cassette('test_oauth2_token_exchange__valid_code'):
+        oauth2_token_exchange(
+            client_id='clientid', client_secret='clientsecret',
+            redirect_uri='http://127.0.0.1:5000/authorize/',
+            code='codegoeshere')
+
+{'token_type': 'Bearer', 'access_token': 'returnedaccesstoken',
+'refresh_token': 'returnedrefreshtoken', 'expires_in': 36000,
+'scope': 'american-gut read wildlife open-humans write pgp go-viral'}
+"""
+import os
+
+import vcr
+
+
+def valid_cassettes():
+    base_dir = os.path.dirname(__file__)
+    return [x for x in os.listdir(base_dir) if x.endswith('.yaml')]
+
+
+def get_vcr():
+    base_dir = os.path.dirname(__file__)
+    my_vcr = vcr.VCR(record_mode='none',
+                     path_transformer=vcr.VCR.ensure_suffix('.yaml'),
+                     cassette_library_dir=base_dir)
+    return my_vcr

--- a/ohapi/cassettes/test_oauth2_token_exchange__invalid_client.yaml
+++ b/ohapi/cassettes/test_oauth2_token_exchange__invalid_client.yaml
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: grant_type=authorization_code&redirect_uri=http%3A%2F%2F127.0.0.1%3A5000%2Fauthorize_openhumans%2F&code=codegoeshere
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic Y2xpZW50aWQ6Y2xpZW50c2VjcmV0]
+      Connection: [keep-alive]
+      Content-Length: ['116']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://www.openhumans.org/oauth2/token/
+  response:
+    body: {string: '{"error": "invalid_client"}'}
+    headers:
+      Cache-Control: [no-store]
+      Connection: [close]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Sun, 04 Mar 2018 23:12:05 GMT']
+      Pragma: [no-cache]
+      Server: [Cowboy]
+      Vary: ['Accept-Language, Cookie']
+      Via: [1.1 vegur]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 401, message: Unauthorized}
+version: 1

--- a/ohapi/cassettes/test_oauth2_token_exchange__invalid_code.yaml
+++ b/ohapi/cassettes/test_oauth2_token_exchange__invalid_code.yaml
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: grant_type=authorization_code&redirect_uri=http%3A%2F%2F127.0.0.1%3A5000%2Fauthorize_openhumans%2F&code=codegoeshere
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic Y2xpZW50aWQ6Y2xpZW50c2VjcmV0]
+      Connection: [keep-alive]
+      Content-Length: ['134']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://www.openhumans.org/oauth2/token/
+  response:
+    body: {string: '{"error": "invalid_grant"}'}
+    headers:
+      Cache-Control: [no-store]
+      Connection: [close]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Sun, 04 Mar 2018 22:56:43 GMT']
+      Pragma: [no-cache]
+      Server: [Cowboy]
+      Vary: ['Accept-Language, Cookie']
+      Via: [1.1 vegur]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 401, message: Unauthorized}
+version: 1

--- a/ohapi/cassettes/test_oauth2_token_exchange__invalid_refresh.yaml
+++ b/ohapi/cassettes/test_oauth2_token_exchange__invalid_refresh.yaml
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: grant_type=refresh_token&refresh_token=refreshtokengoeshere
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic Y2xpZW50aWQ6Y2xpZW50c2VjcmV0]
+      Connection: [keep-alive]
+      Content-Length: ['64']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://www.openhumans.org/oauth2/token/
+  response:
+    body: {string: '{"error": "invalid_grant"}'}
+    headers:
+      Cache-Control: [no-store]
+      Connection: [close]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Sun, 04 Mar 2018 23:21:40 GMT']
+      Pragma: [no-cache]
+      Server: [Cowboy]
+      Vary: ['Accept-Language, Cookie']
+      Via: [1.1 vegur]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 401, message: Unauthorized}
+version: 1

--- a/ohapi/cassettes/test_oauth2_token_exchange__invalid_secret.yaml
+++ b/ohapi/cassettes/test_oauth2_token_exchange__invalid_secret.yaml
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: grant_type=authorization_code&redirect_uri=http%3A%2F%2F127.0.0.1%3A5000%2Fauthorize_openhumans%2F&code=codegoeshere
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic Y2xpZW50aWQ6Y2xpZW50c2VjcmV0]
+      Connection: [keep-alive]
+      Content-Length: ['116']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://www.openhumans.org/oauth2/token/
+  response:
+    body: {string: '{"error": "invalid_client"}'}
+    headers:
+      Cache-Control: [no-store]
+      Connection: [close]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Sun, 04 Mar 2018 23:17:53 GMT']
+      Pragma: [no-cache]
+      Server: [Cowboy]
+      Vary: ['Accept-Language, Cookie']
+      Via: [1.1 vegur]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 401, message: Unauthorized}
+version: 1

--- a/ohapi/cassettes/test_oauth2_token_exchange__valid_code.yaml
+++ b/ohapi/cassettes/test_oauth2_token_exchange__valid_code.yaml
@@ -1,0 +1,30 @@
+interactions:
+- request:
+    body: grant_type=authorization_code&redirect_uri=http%3A%2F%2F127.0.0.1%3A5000%2Fauthorize_openhumans%2F&code=6yNYmUlXN1wLwQFQR0lnUohR1KMeVt
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic Y2xpZW50aWQ6Y2xpZW50c2VjcmV0]
+      Connection: [keep-alive]
+      Content-Length: ['134']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://www.openhumans.org/oauth2/token/
+  response:
+    body: {string: '{"token_type": "Bearer", "access_token": "returnedaccesstoken",
+        "refresh_token": "returnedrefreshtoken", "expires_in": 36000, "scope":
+        "american-gut read wildlife open-humans write pgp go-viral"}'}
+    headers:
+      Cache-Control: [no-store]
+      Connection: [close]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Sun, 04 Mar 2018 23:12:05 GMT']
+      Pragma: [no-cache]
+      Server: [Cowboy]
+      Vary: ['Accept-Language, Cookie']
+      Via: [1.1 vegur]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/ohapi/cassettes/test_oauth2_token_exchange__valid_refresh.yaml
+++ b/ohapi/cassettes/test_oauth2_token_exchange__valid_refresh.yaml
@@ -1,0 +1,30 @@
+interactions:
+- request:
+    body: grant_type=refresh_token&refresh_token=refreshtokengoeshere
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic Y2xpZW50aWQ6Y2xpZW50c2VjcmV0]
+      Connection: [keep-alive]
+      Content-Length: ['69']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://www.openhumans.org/oauth2/token/
+  response:
+    body: {string: '{"scope": "american-gut read wildlife open-humans write pgp go-viral",
+        "access_token": "newaccesstoken", "token_type": "Bearer",
+        "expires_in": 36000, "refresh_token": "newrefreshtoken"}'}
+    headers:
+      Cache-Control: [no-store]
+      Connection: [close]
+      Content-Language: [en]
+      Content-Type: [application/json]
+      Date: ['Sun, 04 Mar 2018 23:17:53 GMT']
+      Pragma: [no-cache]
+      Server: [Cowboy]
+      Vary: ['Accept-Language, Cookie']
+      Via: [1.1 vegur]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/ohapi/tests/test_api.py
+++ b/ohapi/tests/test_api.py
@@ -1,0 +1,82 @@
+from unittest import TestCase
+
+import pytest
+import vcr
+
+from ohapi.api import (
+    SettingsError, oauth2_auth_url, oauth2_token_exchange)
+
+my_vcr = vcr.VCR(path_transformer=vcr.VCR.ensure_suffix('.yaml'),
+                 cassette_library_dir='ohapi/cassettes')
+
+
+class APITest(TestCase):
+
+    TESTING_KWARGS_OAUTH2_TOKEN_EXCHANGE = {
+        'client_id': 'clientid',
+        'client_secret': 'clientsecret',
+        'redirect_uri': 'http://127.0.0.1:5000/authorize_openhumans/',
+    }
+
+    def setUp(self):
+        pass
+
+    def test_oauth2_auth_url__no_client_id(self):
+        with pytest.raises(SettingsError):
+            oauth2_auth_url()
+
+    def test_oauth2_auth_url__with_client_id(self):
+        auth_url = oauth2_auth_url(client_id='abcd1234')
+        assert auth_url == (
+            'https://www.openhumans.org/direct-sharing/projects/'
+            'oauth2/authorize/?client_id=abcd1234&response_type=code')
+
+    @my_vcr.use_cassette()
+    def test_oauth2_token_exchange__valid_code(self):
+        data = oauth2_token_exchange(
+            code='codegoeshere', **self.TESTING_KWARGS_OAUTH2_TOKEN_EXCHANGE)
+        assert data == {
+            'access_token': 'returnedaccesstoken',
+            'expires_in': 36000,
+            'refresh_token': 'returnedrefreshtoken',
+            'scope': 'american-gut read wildlife open-humans write '
+                     'pgp go-viral',
+            'token_type': 'Bearer'}
+
+    @my_vcr.use_cassette()
+    def test_oauth2_token_exchange__invalid_code(self):
+        data = oauth2_token_exchange(
+            code='codegoeshere', **self.TESTING_KWARGS_OAUTH2_TOKEN_EXCHANGE)
+        assert data == {'error': 'invalid_grant'}
+
+    @my_vcr.use_cassette()
+    def test_oauth2_token_exchange__invalid_client(self):
+        data = oauth2_token_exchange(
+            code='codegoeshere', **self.TESTING_KWARGS_OAUTH2_TOKEN_EXCHANGE)
+        assert data == {'error': 'invalid_client'}
+
+    @my_vcr.use_cassette()
+    def test_oauth2_token_exchange__invalid_secret(self):
+        data = oauth2_token_exchange(
+            code='codegoeshere', **self.TESTING_KWARGS_OAUTH2_TOKEN_EXCHANGE)
+        assert data == {'error': 'invalid_client'}
+
+    @my_vcr.use_cassette()
+    def test_oauth2_token_exchange__valid_refresh(self):
+        data = oauth2_token_exchange(
+            refresh_token='refreshtokengoeshere',
+            **self.TESTING_KWARGS_OAUTH2_TOKEN_EXCHANGE)
+        assert data == {
+            'access_token': 'newaccesstoken',
+            'expires_in': 36000,
+            'refresh_token': 'newrefreshtoken',
+            'scope': 'american-gut read wildlife open-humans write '
+                     'pgp go-viral',
+            'token_type': 'Bearer'}
+
+    @my_vcr.use_cassette()
+    def test_oauth2_token_exchange__invalid_refresh(self):
+        data = oauth2_token_exchange(
+            refresh_token='refreshtokengoeshere',
+            **self.TESTING_KWARGS_OAUTH2_TOKEN_EXCHANGE)
+        assert data == {'error': 'invalid_grant'}

--- a/ohapi/tests/test_api.py
+++ b/ohapi/tests/test_api.py
@@ -31,6 +31,14 @@ class APITest(TestCase):
             'https://www.openhumans.org/direct-sharing/projects/'
             'oauth2/authorize/?client_id=abcd1234&response_type=code')
 
+    def test_oauth2_auth_url__with_client_id_and_redirect_uri(self):
+        auth_url = oauth2_auth_url(client_id='abcd1234',
+                                   redirect_uri='http://127.0.0.1:5000/auth/')
+        assert auth_url == (
+            'https://www.openhumans.org/direct-sharing/projects/'
+            'oauth2/authorize/?client_id=abcd1234&response_type=code'
+            '&redirect_uri=http%3A%2F%2F127.0.0.1%3A5000%2Fauth%2F')
+
     @my_vcr.use_cassette()
     def test_oauth2_token_exchange__valid_code(self):
         data = oauth2_token_exchange(

--- a/ohapi/tests/test_cassettes.py
+++ b/ohapi/tests/test_cassettes.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from ohapi.cassettes import get_vcr, valid_cassettes
+
+
+class CasettesTest(TestCase):
+    def setUp(self):
+        pass
+
+    def test_get_vcr(self):
+        get_vcr()
+
+    def test_valid_cassettes(self):
+        valid_cassettes()


### PR DESCRIPTION
Adds a reusable VCR and starts creating cassettes and tests for functions using the Open Humans API.

## General Checkups
- [x] Have you checked that there aren't other open pull requests for the same issue/update/change?
- [x] If your code includes new features and not just bug fixes/copy editing: Did you include new tests?

## Description
Adds use of `vcrpy` to record API calls as "cassettes".

These cassettes are stored within the package itself, for (a) use in development and testing of this module (b) reuse by others.

To start implementing the former, tests were written for `oauth2_token_exchange` from `ohapi.api`; in the process this seems to have uncovered and repaired a bug.

To enable the latter, the following functions from `ohapi.cassettes` can be used to discover cassettes and run them with a custom read-only VCR:
* `get_vcr`: return a read-only VCR that can be used with cassettes listed by `valid_cassettes`
* `valid_cassettes`: return a list of valid cassettes

## Related Issue

Related to #14 (adding tests) and also #16 (which is blocking on having tests for `ohapi.api` functions).

## Example

Below is an example of using the custom VCR to mock the response of the Open Humans API's token exchange endpoint, in a situation where a valid code is being provided.

```
>>> from ohapi.cassettes import get_vcr, valid_cassettes
>>> from ohapi.api import oauth2_token_exchange
>>> valid_cassettes()

['test_oauth2_token_exchange__valid_refresh.yaml',
'test_oauth2_token_exchange__invalid_secret.yaml',
'test_oauth2_token_exchange__valid_code.yaml',
'test_oauth2_token_exchange__invalid_client.yaml',
'test_oauth2_token_exchange__invalid_code.yaml',
'test_oauth2_token_exchange__invalid_refresh.yaml']

>>> with ohapi_vcr.use_cassette('test_oauth2_token_exchange__valid_code'):
        oauth2_token_exchange(client_id='clientid', client_secret='clientsecret',
        redirect_uri='http://127.0.0.1:5000/authorize_openhumans/', code='codegoeshere')

{'token_type': 'Bearer', 'access_token': 'returnedaccesstoken',
'refresh_token': 'returnedrefreshtoken', 'expires_in': 36000,
'scope': 'american-gut read wildlife open-humans write pgp go-viral'}
```