### PR TITLE
wrong parameter passed to AWS S3 url

### DIFF
--- a/ohapi/api.py
+++ b/ohapi/api.py
@@ -340,11 +340,13 @@ def upload_aws(target_filepath, metadata, access_token, base_url=OH_BASE_URL,
         response = exchange_oauth2_member(access_token)
         project_member_id = response['project_member_id']
 
+    filename = target_filepath.split("/")[-1]
+
     r = requests.post(url, data={'project_member_id': project_member_id,
                                  'metadata': json.dumps(metadata),
-                                 'filename': target_filepath})
+                                 'filename': filename})
     requests.put(url=r.json()['url'],
-                 data={'data_file': open(target_filepath, 'rb')})
+                 data=open(target_filepath, 'rb'))
     done = urlparse.urljoin(
         base_url,
         '/api/direct-sharing/project/files/upload/complete/?{}'.format(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     description='Tools for working with Open Humans APIs',
     long_description=readme(),
 
-    version='0.1.7',
+    version='0.2.2',
 
     license='MIT',
 


### PR DESCRIPTION
The AWS S3 upload still failed because of a wrong URL parameter. This error isn't obvious though, instead the AWS S3 Error-XML was faithfully uploaded to OH instead…

I tested this now and it now correctly uploads files. 

Let this be a lesson what happens if you don't write enough tests. m( 

@madprime I'll merge this right away and I bumped the version. Can you deploy to PyPI?